### PR TITLE
Hopeful fix for Geoboundaries aggregation

### DIFF
--- a/R/process_geoboundaries.R
+++ b/R/process_geoboundaries.R
@@ -29,7 +29,7 @@ admin2$iso3<-admin2$shapeGroup
 
 # Several Admin0 fields are missing
 admin0$ID<-1:length(admin0)
-admin0_rast<-terra::rasterize(admin0, rast(), field = "ID")
+admin0_rast<-terra::rasterize(admin0, base_rast, field = "ID")
 Mode <- function(x) {
   x<-x$value
   x<-x[!is.na(x)]

--- a/R/process_geoboundaries.R
+++ b/R/process_geoboundaries.R
@@ -21,9 +21,7 @@ admin0$iso3<-admin0$shapeGroup
 # Admin1
 admin1$admin0_name<-countrycode::countrycode(admin1$shapeGroup, origin = 'iso3c', destination = 'country.name')
 admin1$iso3<-admin1$shapeGroup
-
-admin1$admin1_name<-admin1$shapeName
-admin1$ID<-1:length(admin1)
+admin1$admin1_name <- admin1$shapeName
 
 # Admin2
 admin2$admin0_name<-countrycode::countrycode(admin2$shapeGroup, origin = 'iso3c', destination = 'country.name')
@@ -31,7 +29,7 @@ admin2$iso3<-admin2$shapeGroup
 
 # Several Admin0 fields are missing
 admin0$ID<-1:length(admin0)
-admin0_rast<-terra::rasterize(admin0,base_rast,"ID")
+admin0_rast<-terra::rasterize(admin0, rast(), field = "ID")
 Mode <- function(x) {
   x<-x$value
   x<-x[!is.na(x)]
@@ -45,7 +43,12 @@ X<-sapply(X,Mode)
 admin2$admin0_name<-admin0$admin0_name[match(X,admin0$ID)]
 admin2$iso3<-admin0$iso3[match(X,admin0$ID)]
 
+# Several Admin1 fields are missing
+data.frame(admin1[is.na(admin1$admin_name)])
+
+
 # Add Admin 1 to Admin2
+admin1$ID <- 1:length(admin1)
 admin1_rast<-terra::rasterize(admin1,base_rast,"ID")
 
 X<-exactextractr::exact_extract(admin1_rast,sf::st_as_sf(admin2),progress=F)
@@ -53,9 +56,13 @@ X<-sapply(X,Mode)
 admin2$admin1_name<-admin1$admin1_name[match(X,admin1$ID)]
 admin2$admin2_name<-str_to_title(admin2$shapeName)
 
-# There are few instances where the match doesn't work, we will need to address these3
+# There are few instances where the match doesn't work, we will need to address these
 data.frame(admin2[is.na(admin2$admin1_name)])
-admin2$admin1_name[is.na(admin2$admin1_name)]<-c("Banjul","Banjul","Collines","Elobey Chico","Elobey Grande")
+missing_a1 <- c("Collines", "Collines", "Banjul", "Banjul", "Banjul",
+  "Cabo Delgado", "Cabo Delgado", "Litoral", "Elobey Chico", "Elobey Grande")
+admin2$admin1_name[is.na(admin2$admin1_name)] <- missing_a1
+# DOUBLE CHECK @Pete - for me length of list below != length of missing.. but I may be testing a different admin dataset
+# admin2$admin1_name[is.na(admin2$admin1_name)]<-c("Banjul","Banjul","Collines","Elobey Chico","Elobey Grande")
 
 data.frame(admin2[is.na(admin2$admin0_name)])
 admin2$iso3[is.na(admin2$admin0_name)]<-admin2$shapeGroup[is.na(admin2$admin0_name)]
@@ -64,17 +71,49 @@ admin2$admin0_name[is.na(admin2$admin0_name)]<-countrycode::countrycode(admin2$s
 data.frame(admin1[is.na(admin1$admin0_name)])
 #admin1$shapeGroup[is.na(admin1$admin0_name)]<-countrycode::countrycode(admin1$shapeGroup[is.na(admin1$admin0_name)], origin = 'iso3c', destination = 'country.name')
 
-admin0[,c("ID","shapeName","shapeISO","shapeID","shapeGroup","shapeType","agg_n")]<-NULL
-admin1[,c("ID","shapeName","shapeISO","shapeID","shapeGroup","shapeType","agg_n")]<-NULL
-admin2[,c("ID","shapeName","shapeISO","shapeID","shapeGroup","shapeType","agg_n")]<-NULL
+
+admin0[, c("ID", "shapeName", "shapeISO", "shapeID", "shapeGroup", "shapeType", "agg_n")]<-NULL
+admin1[, c("ID", "shapeName", "shapeISO", "shapeID", "shapeGroup", "shapeType", "agg_n")] <- NULL
+admin2[, c("ID", "shapeName", "shapeISO", "shapeID", "shapeGroup", "shapeType", "agg_n")] <- NULL
 
 # Merge polygons
-admin0<-terra::aggregate(admin0,by="admin_name")
-admin1<-terra::aggregate(admin1,by="admin_name")
-admin2<-terra::aggregate(admin2,by="admin_name")
+
+# Pre-calc the correct unique aggregated rows
+a0_check <- nrow(unique(as.data.frame(admin0)))
+a1_check <- nrow(unique(as.data.frame(admin1)))
+a2_check <- nrow(unique(as.data.frame(admin2)))
+
+# Aggregate
+admin0 <- terra::aggregate(admin0,
+  by = "admin_name", count = FALSE, na.rm = FALSE)
+if (a0_check != nrow(admin0)) stop("Admin 0 merge error")
+
+admin1$a1_a0 <- paste0(admin1$admin_name,"_", admin1$admin0_name)
+admin1 <- terra::aggregate(admin1, by = "a1_a0", count = FALSE)
+
+# This method also works but is more sensitive to NA
+# admin1 <- terra::aggregate(admin1,
+#   by = c("admin_name", "admin0_name"),
+#   fun = "modal", count = FALSE, na.rm = TRUE)
+if (a1_check != nrow(admin1)) stop("Admin 1 merge error")
+
+admin2$a2_a1_a0 <- paste0(admin2$admin_name,"_", admin2$admin1_name, "_", admin2$admin0_name)
+admin2 <- terra::aggregate(admin2, by = 'a2_a1_a0', count = FALSE)
+if (a2_check != nrow(admin2)) stop("Admin 2 merge error")
+
+# final sanity check
+if (any(!sort(unique(admin0$admin_name)) == sort(unique(admin1$admin0_name)))) {
+  stop("Not all Admin 0 match with Admin 1")
+}
+if (any(!sort(unique(admin0$admin_name)) == sort(unique(admin2$admin0_name)))) {
+  stop("Not all Admin 0 match with Admin 1")
+}
+
+
+
+
 
 # Save processed files
 terra::writeVector(admin0,file="Data/geoboundaries/admin0_processed.shp",overwrite=T)
 terra::writeVector(admin1,file="Data/geoboundaries/admin1_processed.shp",overwrite=T)
 terra::writeVector(admin2,file="Data/geoboundaries/admin2_processed.shp",overwrite=T)
-


### PR DESCRIPTION
A simple solution given how long it took to solve. Made a distinct column for each admin 1 - admin 0 combination for the admin 1 aggregate (and admin 0, 1, 2 for the admin 2 aggregate.) Also added some sanity checks just to be safe. The number of manually added admin 1 names is larger for my test dataset, and therefore longer in this commit (line 61-62). Worth checking against your data to make sure that is correct. 