### PR TITLE
create a high resolution base raster to rasterize the admin levels.

### DIFF
--- a/R/process_geoboundaries.R
+++ b/R/process_geoboundaries.R
@@ -11,7 +11,7 @@ admin1$admin_name<-str_to_title(admin1$shapeName)
 admin0$admin_name<-str_to_title(admin0$shapeName)
 
 # Create standard name field for each admin vector
-base_rast<-terra::rast(extent = terra::ext(admin0), resolution = 0.01, crs = "epsg:4326")
+base_rast<-terra::rast(extent = terra::ext(admin0), resolution = 0.007, crs = "epsg:4326")
 # Admin0
 admin0$admin0_name<-countrycode::countrycode(admin0$shapeGroup, origin = 'iso3c', destination = 'country.name')
 admin0$admin_name<-admin0$admin0_name
@@ -111,6 +111,6 @@ if (any(!sort(unique(admin0$admin_name)) == sort(unique(admin2$admin0_name)))) {
 }
 
 # Save processed files
-terra::writeVector(admin0,file="Data/geoboundaries/admin0_REprocessed.shp",overwrite=T)
-terra::writeVector(admin1,file="Data/geoboundaries/admin1_REprocessed.shp",overwrite=T)
-terra::writeVector(admin2,file="Data/geoboundaries/admin2_REprocessed.shp",overwrite=T)
+terra::writeVector(admin0,file="Data/geoboundaries/admin0_processed.gpkg",overwrite=T)
+terra::writeVector(admin1,file="Data/geoboundaries/admin1_processed.gpkg",overwrite=T)
+terra::writeVector(admin2,file="Data/geoboundaries/admin2_processed.gpkg",overwrite=T)

--- a/R/process_geoboundaries.R
+++ b/R/process_geoboundaries.R
@@ -11,8 +11,7 @@ admin1$admin_name<-str_to_title(admin1$shapeName)
 admin0$admin_name<-str_to_title(admin0$shapeName)
 
 # Create standard name field for each admin vector
-base_rast<-terra::rast(list.files("Data/hazard_classified/annual",".tif",full.names = T))[[1]]
-
+base_rast<-terra::rast(extent = terra::ext(admin0), resolution = 0.01, crs = "epsg:4326")
 # Admin0
 admin0$admin0_name<-countrycode::countrycode(admin0$shapeGroup, origin = 'iso3c', destination = 'country.name')
 admin0$admin_name<-admin0$admin0_name
@@ -46,19 +45,15 @@ admin2$iso3<-admin0$iso3[match(X,admin0$ID)]
 # Add Admin 1 to Admin2
 admin1$ID <- 1:length(admin1)
 admin1_rast<-terra::rasterize(admin1,base_rast,"ID")
-
 X<-exactextractr::exact_extract(admin1_rast,sf::st_as_sf(admin2),progress=F)
 X<-sapply(X,Mode)
 admin2$admin1_name<-admin1$admin1_name[match(X,admin1$ID)]
 admin2$admin2_name<-str_to_title(admin2$shapeName)
 
-
 # There are few instances where the match doesn't work, we will need to address these
 data.frame(admin2[is.na(admin2$admin1_name)])
-missing_a1 <- c("Collines", "Collines", "Banjul", "Banjul", "Banjul",
-  "Cabo Delgado", "Cabo Delgado", "Litoral", "Elobey Chico", "Elobey Grande")
+missing_a1 <- c('Collines', 'Collines', 'Elobey Chico')
 admin2$admin1_name[is.na(admin2$admin1_name)] <- missing_a1
-# DOUBLE CHECK @Pete - for me length of list below != length of missing.. but I may be testing a different admin dataset
 # admin2$admin1_name[is.na(admin2$admin1_name)]<-c("Banjul","Banjul","Collines","Elobey Chico","Elobey Grande")
 
 # Add missing iso3 codes to admin2
@@ -82,23 +77,20 @@ admin0[, c("ID", "shapeName", "shapeISO", "shapeID", "shapeGroup", "shapeType", 
 admin1[, c("ID", "shapeName", "shapeISO", "shapeID", "shapeGroup", "shapeType", "agg_n")] <- NULL
 admin2[, c("ID", "shapeName", "shapeISO", "shapeID", "shapeGroup", "shapeType", "agg_n")] <- NULL
 
-# Merge polygons
-
-
+### Merge polygons
 # Pre-calc the correct unique aggregated rows
 
 a0_check <- nrow(unique(as.data.frame(admin0)))
 a1_check <- nrow(unique(as.data.frame(admin1)))
 a2_check <- nrow(unique(as.data.frame(admin2)))
 
-
 # Aggregate
 admin0 <- terra::aggregate(admin0,
   by = "admin_name", count = FALSE, na.rm = FALSE)
 if (a0_check != nrow(admin0)) stop("Admin 0 merge error")
 
-admin1$a1_a0 <- paste0(admin1$admin_name,"_", admin1$admin0_name)
-admin1 <- terra::aggregate(admin1, by = "a1_a0", count = FALSE)
+# admin1$a1_a0 <- paste0(admin1$admin_name,"_", admin1$admin0_name)
+admin1 <- terra::aggregate(admin1, by = c('admin1_name', 'admin0_name'), count = FALSE)
 
 # This method also works but is more sensitive to NA
 # admin1 <- terra::aggregate(admin1,
@@ -106,8 +98,8 @@ admin1 <- terra::aggregate(admin1, by = "a1_a0", count = FALSE)
 #   fun = "modal", count = FALSE, na.rm = TRUE)
 if (a1_check != nrow(admin1)) stop("Admin 1 merge error")
 
-admin2$a2_a1_a0 <- paste0(admin2$admin_name,"_", admin2$admin1_name, "_", admin2$admin0_name)
-admin2 <- terra::aggregate(admin2, by = 'a2_a1_a0', count = FALSE)
+# admin2$a2_a1_a0 <- paste0(admin2$admin_name,"_", admin2$admin1_name, "_", admin2$admin0_name)
+admin2 <- terra::aggregate(admin2, by = c('admin2_name', 'admin1_name', 'admin0_name'), count = FALSE)
 if (a2_check != nrow(admin2)) stop("Admin 2 merge error")
 
 # final sanity check
@@ -119,6 +111,6 @@ if (any(!sort(unique(admin0$admin_name)) == sort(unique(admin2$admin0_name)))) {
 }
 
 # Save processed files
-terra::writeVector(admin0,file="Data/geoboundaries/admin0_processed.shp",overwrite=T)
-terra::writeVector(admin1,file="Data/geoboundaries/admin1_processed.shp",overwrite=T)
-terra::writeVector(admin2,file="Data/geoboundaries/admin2_processed.shp",overwrite=T)
+terra::writeVector(admin0,file="Data/geoboundaries/admin0_REprocessed.shp",overwrite=T)
+terra::writeVector(admin1,file="Data/geoboundaries/admin1_REprocessed.shp",overwrite=T)
+terra::writeVector(admin2,file="Data/geoboundaries/admin2_REprocessed.shp",overwrite=T)


### PR DESCRIPTION
This fixes the problem where certain small admin 2 units were placed into the wrong admin 1, and occasionally the wrong admin 0, due to the rasterized pixels causing the mode to shift when extracted. Basically pixels overlapping the border of an admin unit were included in calculating the mode, and if the admin unit was relatively small or there were a large number of these overlapping pixels, the error would occur. Setting the raster resolution to 0.007 seemed to fix it - I also tested it at 0.004 and there was no difference, so I reverted it back to 0.007 for performance. It is possible an error could still exist, but Likoma in Malawi is correct, and it is a should be a fairly robust test case given the small size and it being completely surrounded by Mozambique territory. 